### PR TITLE
Add instructions for Emacs support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,44 @@ Installation (from pypi)
 Usage in IDE
 ------------
 
+IntelliJ Based IDE
+~~~~~~~~~~~~~~~~~~
+
 For any IntelliJ based IDE (such as PyCharm, WebStorm or PhpStorm) you need to
 install a LSP (Language Server Protocol) plugin.
 Then add ``mpfls`` as ``Raw command`` for ``yaml`` files in
 "Settings -> Languages & Frameworks -> Language Server Protocol -> Server Definitions".
 
+VSCode
+~~~~~~
+
 For vsCode install the extension in `vscode-client <https://github.com/missionpinball/mpf-ls/tree/master/vscode-client>`_.
 
+Emacs
+~~~~~
+
+Integration with Emacs is accomplished using `lsp-mode <https://github.com/emacs-lsp/lsp-mode>`_.
+
+A minimal completion setup can be achieved with the :code:`lsp-mode`, :code:`yaml-mode`, :code:`company`, and :code:`lsp-company` packages.  Company is a general purpose completion package for Emacs.  :code:`lsp-company` is a helper package for using Company with :code`lsp-mode`.
+
+1. Install :code:`lsp-mode`, :code:`company`, :code:`yaml-mode`, and :code:`lsp-company` by running :code:`M-x package-install` and following the instructions.
+2. Add the following to your Emacs init file: ::
+
+     ;; Register the mpfls server
+     (require 'lsp-mode)
+     (add-hook 'yaml-mode-hook #'lsp)
+     (defvar lsp-language-id-configuration
+       '((yaml-mode . "mpfls")))
+
+     (lsp-register-client
+       (make-lsp-client :new-connection (lsp-stdio-connection "mpfls")
+         :major-modes '(yaml-mode)
+         :server-id 'mpfls))
+     (add-hook 'after-init-hook 'global-company-mode)
+
+     ;; Configure company-lsp
+     (require 'company-lsp)
+     (push 'company-lsp company-backends)
 
 Installation (from git for local development)
 ---------------------------------------------
@@ -38,4 +69,3 @@ License
 
 This project is made available under the MIT License.
 Code is based on the `Python language server <https://github.com/palantir/python-language-server/>`_ (also MIT).
-


### PR DESCRIPTION
Here are some instructions to get mpf-ls integrated with Emacs.  I tested this by following the instructions and then opening the `config.yaml` in one of my MPF projects.  MPF completion candidates appear automatically or when I manually trigger a request for completion.  

One thing I noticed was that if I was filling out the `driverboards` field then I didn't see a completion candidate appear when I started typing `p3_roc`.  Not sure if that is expected but if it isn't then let me know and I can dig deeper.