### PR TITLE
fix issue detecting show config files inside modes

### DIFF
--- a/mpfls/workspace.py
+++ b/mpfls/workspace.py
@@ -158,10 +158,10 @@ class Workspace(object):
             self.show_message("{} is not in workspace {}. MPF Language Server will not work.".format(path,
                                                                                                      self.root_path))
 
-        if path.startswith(self.mode_path + os.sep):
-            config_type = TYPE_MODE
-        elif path.startswith(self.show_path + os.sep):
+        if path.find(os.sep + 'shows' + os.sep) != -1:
             config_type = TYPE_SHOW
+        elif path.startswith(self.mode_path + os.sep):
+            config_type = TYPE_MODE
         else:
             config_type = TYPE_MACHINE
 


### PR DESCRIPTION
Not all files inside a mode are TYPE_MODE, so moved the check for TYPE_SHOW above, and also changed the pattern matching to match anything inside a folder named shows.